### PR TITLE
fix(ionic-webview): convert file url correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ If using in an Cordova App, the following plugins are required:
 
 - `cordova-plugin-file`
 - `cordova-plugin-file-transfer`
+- `cordova-plugin-ionic-webview@2.3.2`
 
 ## Quick Start
 

--- a/lib/cordovaLoad.js
+++ b/lib/cordovaLoad.js
@@ -19,7 +19,7 @@ export default function cordovaLoad(serverRoot, forceReload, manifest, onProgres
   });
   window.cordovaFileCache = {
     get: (path) => {
-      return cache.get(path).replace(/^file:\/\//, '');
+      return window.Ionic.WebView.convertFileSrc(cache.get(path));
     }
   };
 
@@ -40,11 +40,11 @@ export default function cordovaLoad(serverRoot, forceReload, manifest, onProgres
     return Promise.all(manifest.domNodes.map(throat(1, (nodeInfo) => {
       if (nodeInfo.type === 'css') {
         if (!nodeInfo.path.match(/^http(s|):\/\//)) {
-          nodeInfo.path = `${serverRoot}${nodeInfo.path}`;
+          nodeInfo.path = window.Ionic.WebView.convertFileSrc(`${serverRoot}${nodeInfo.path}`);
         }
       } else {
         const cachePath = cache.get(nodeInfo.path);
-        nodeInfo.path = cachePath.replace(/^file:\/\//, '');
+        nodeInfo.path = window.Ionic.WebView.convertFileSrc(cachePath);
       }
       return new DomNode(nodeInfo);
     })));


### PR DESCRIPTION
In xcode 11, osx 10.15 there's an issue where ionic-webview plugin is not generating the correct filesystem url. see https://github.com/ionic-team/cordova-plugin-ionic-webview/blob/2.x/src/www/util.js#L12

**breaking changes**

If you're not using `cordova-plugin-ionic-webview` 2.3.2 this might break for you

fixes https://tablecheck.atlassian.net/browse/TS-4941