### PR TITLE
fix: ensure Loader always returns an emitter

### DIFF
--- a/lib/Loader.js
+++ b/lib/Loader.js
@@ -30,13 +30,15 @@ export default class Loader {
         this.config.publicPath = `${this.config.appHostTablet}/`;
       }
     }
-
+    
+    let promise;
     if (!isCordova) {
-      return this.normalLoad();
+      promise = this.normalLoad();
+    } else {
+      promise = this.cacheLoad(!this.config.useLocalCache || forceReload)
     }
-
-    this.cacheLoad(!this.config.useLocalCache || forceReload)
-    .then(() => {
+    
+    promise.then(() => {
       this.emitter.emit('loaded');
     })
     .catch((e) => {


### PR DESCRIPTION
The "normalLoad" path was returning a promise instead of an emitter resulting in an error.