### PR TITLE
fix: Fix startLoading default

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -103,7 +103,7 @@ function getConfig() {
   );
 }
 
-function startLoading(event) {
+function startLoading(event = {}) {
   if (event.type === 'deviceready') {
     deviceReady = true;
   }


### PR DESCRIPTION
error reload is breaking because it will throw error on this missing default value